### PR TITLE
Enables to customize config easily

### DIFF
--- a/src/_config.sass
+++ b/src/_config.sass
@@ -1,63 +1,63 @@
 // Base
 // ==========================================================================
-$bg-loader: rgba(0, 0, 0, .85)
-$font-loader: Helvetica, Arial, sans-serif
-$font-size-loader: 14px
+$bg-loader: rgba(0, 0, 0, .85) !default
+$font-loader: Helvetica, Arial, sans-serif !default
+$font-size-loader: 14px !default
 
 // Loader default
 // ==========================================================================
-$loader--size: 48px
-$loader--color: #fff
-$loader--text-color: #fff
+$loader--size: 48px !default
+$loader--color: #fff !default
+$loader--text-color: #fff !default
 
 // Loader double
 // ==========================================================================
-$loader-double--color: #fff
-$loader-double--color-external: #eb974e
-$loader-double--size: 48px
-$loader-double--border: 8px
+$loader-double--color: #fff !default
+$loader-double--color-external: #eb974e !default
+$loader-double--size: 48px !default
+$loader-double--border: 8px !default
 
 // Loader bar
 // ==========================================================================
-$loader-bar--color: #52b3d9
-$loader-bar--color-secondary: #4183d7
-$loader-bar--text-color: #fff
+$loader-bar--color: #52b3d9 !default
+$loader-bar--color-secondary: #4183d7 !default
+$loader-bar--text-color: #fff !default
 
 // Loader bar ping pong
 // ==========================================================================
-$loader-bar-ping--bar: #000
-$loader-bar-ping--ticker: #f19
+$loader-bar-ping--bar: #000 !default
+$loader-bar-ping--ticker: #f19 !default
 
 // Loader border
 // ==========================================================================
-$loader-border--width: 15px
-$loader-border--height: 15px
-$loader-border--text-color: #fff
-$loader-border--color: #ff0
+$loader-border--width: 15px !default
+$loader-border--height: 15px !default
+$loader-border--text-color: #fff !default
+$loader-border--color: #ff0 !default
 
 // Loader ball
 // ==========================================================================
-$loader-ball--color: #fff
-$loader-ball--shadow: rgba(0, 0, 0, .5)
+$loader-ball--color: #fff !default
+$loader-ball--shadow: rgba(0, 0, 0, .5) !default
 
 // Loader smartphone
 // ==========================================================================
-$loader-smartphone--color: #fd0
-$loader-smartphone--text-color: #fff
+$loader-smartphone--color: #fd0 !default
+$loader-smartphone--text-color: #fff !default
 
 // Loader clock
 // ==========================================================================
-$loader-clock--color: #2ecc71
-$loader-clock--color-bg: #f5f5f5
-$loader-clock--color-border: #555
+$loader-clock--color: #2ecc71 !default
+$loader-clock--color-bg: #f5f5f5 !default
+$loader-clock--color-border: #555 !default
 
 // Loader curtain
 // ==========================================================================
-$loader-mask--size: 70px
-$loader-mask--color: #666
-$loader-mask--color-mask: #fff
+$loader-mask--size: 70px !default
+$loader-mask--color: #666 !default
+$loader-mask--color-mask: #fff !default
 
-$loader-mask--color-blue: #3498db
-$loader-mask--color-green: #2ecc71
-$loader-mask--color-yellow: #f1c40f
-$loader-mask--color-red: #e74c3c
+$loader-mask--color-blue: #3498db !default
+$loader-mask--color-green: #2ecc71 !default
+$loader-mask--color-yellow: #f1c40f !default
+$loader-mask--color-red: #e74c3c !default


### PR DESCRIPTION
This PR enables to override configurable variables easily during importing sass files and using them.

Example:
```
// Customize loader background color
$bg-loader: rgba(255, 0, 0, .2);

@import '~pure-css-loader/src/loader-default';

// Your styles
```